### PR TITLE
Feature: lambda for triggering Applications (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lambda/bin
 
 # Ignore the Lambda runtime emulator
 lambda/service/aws-lambda-rie
+
+# vscode files
+.vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ override.tf.json
 # Ignore Lambda Bin folder
 lambda/bin
 
+# Ignore the Lambda runtime emulator
+lambda/service/aws-lambda-rie

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,12 @@
+FROM golang:1.18-alpine
+  
+  # Install git
+RUN set -ex; \
+apk update; \
+apk add --no-cache git
+ 
+  # Set working directory 
+WORKDIR /go/src/github.com/pennsieve/integration-service
+  
+  # Run tests
+CMD CGO_ENABLED=0 sh run_tests.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,11 +14,11 @@ ansiColor('xterm') {
 
   try {
     stage("Run Tests") {
-//       try {
-//         sh "IMAGE_TAG=${imageTag} make test-ci"
-//       } finally {
-//         sh "make docker-clean"
-//       }
+      try {
+        sh "IMAGE_TAG=${imageTag} make test-ci"
+      } finally {
+        sh "make docker-clean"
+      }
     }
 
     if(isMain) {

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test-ci:
 	docker-compose -f docker-compose.test.yml down --remove-orphans
 	mkdir -p data plugins conf logs
 	chmod -R 777 conf
-	@IMAGE_TAG=$(IMAGE_TAG) docker-compose -f docker-compose.test.yml up --exit-code-from=ci-tests ci-tests
+	@IMAGE_TAG=$(IMAGE_TAG) docker-compose -f docker-compose.test.yml up --exit-code-from=ci_tests ci_tests
 
 # Spin down active docker containers.
 docker-clean:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LAMBDA_BUCKET ?= "pennsieve-cc-lambda-functions-use1"
 WORKING_DIR   ?= "$(shell pwd)"
 API_DIR ?= "api"
 SERVICE_NAME  ?= "integration-service"
+SERVICE_PACKAGE_NAME ?= "integration-service-${IMAGE_TAG}.zip"
 PACKAGE_NAME  ?= "${SERVICE_NAME}-${IMAGE_TAG}.zip"
 
 .DEFAULT: help
@@ -39,13 +40,22 @@ docker-clean:
 package:
 	@echo ""
 	@echo "***********************"
-	@echo "*   Packaging lambda   *"
+	@echo "*   Packaging Python lambda   *"
 	@echo "***********************"
 	@echo ""
 	cd $(WORKING_DIR)/lambda/ ; \
 		mkdir bin; \
 		cd event_lambda/; \
 			zip -r $(WORKING_DIR)/lambda/bin/$(PACKAGE_NAME) .
+	@echo ""
+	@echo "***********************"
+	@echo "*   Building integration Service lambda   *"
+	@echo "***********************"
+	@echo ""
+	cd $(WORKING_DIR)/lambda/service; \
+  		env GOOS=linux GOARCH=amd64 go build -o $(WORKING_DIR)/lambda/bin/service/pennsieve_integration_service; \
+		cd $(WORKING_DIR)/lambda/bin/service/ ; \
+			zip -r $(WORKING_DIR)/lambda/bin/service/$(SERVICE_PACKAGE_NAME) .
 
 # Copy Service lambda to S3 location
 publish:
@@ -55,5 +65,12 @@ publish:
 	@echo "*   Publishing lambda   *"
 	@echo "*************************"
 	@echo ""
-	aws s3 cp $(WORKING_DIR)/lambda/bin/$(PACKAGE_NAME) s3://$(LAMBDA_BUCKET)/$(SERVICE_NAME)/
+	aws s3 cp $(WORKING_DIR)/lambda/bin/$(PACKAGE_NAME) s3://$(LAMBDA_BUCKET)/$(SERVICE_NAME)/event_handler/
 	rm -rf $(WORKING_DIR)/lambda/bin/$(PACKAGE_NAME)
+	@echo ""
+	@echo "*************************"
+	@echo "*   Publishing Service lambda   *"
+	@echo "*************************"
+	@echo ""
+	aws s3 cp $(WORKING_DIR)/lambda/bin/service/$(SERVICE_PACKAGE_NAME) s3://$(LAMBDA_BUCKET)/$(SERVICE_NAME)/service/
+	rm -rf $(WORKING_DIR)/lambda/bin/service/$(SERVICE_PACKAGE_NAME)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+networks:
+  api-tests:
+    driver: bridge
+
+services:
+  # Test Container for running tests locally
+  local_tests:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    volumes:
+      - $PWD:/go/src/github.com/pennsieve/integration-service
+    networks:
+      - api-tests
+
+    # Test Container for running tests on CI
+  ci_tests:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    volumes:
+      - $PWD:/go/src/github.com/pennsieve/integration-service
+    networks:
+      - api-tests    

--- a/lambda/service/Dockerfile
+++ b/lambda/service/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /service
 COPY go.mod go.sum ./
 # Build
 COPY main.go .
+COPY handler ./handler
+COPY models ./models
 RUN go build -o main main.go
 # Copy artifacts to a clean image
 FROM alpine:3.16

--- a/lambda/service/Dockerfile
+++ b/lambda/service/Dockerfile
@@ -9,6 +9,7 @@ COPY models ./models
 COPY store ./store
 COPY trigger ./trigger
 COPY clients ./clients
+COPY utils ./utils
 RUN go build -o main main.go
 # Copy artifacts to a clean image
 FROM alpine:3.16

--- a/lambda/service/Dockerfile
+++ b/lambda/service/Dockerfile
@@ -6,6 +6,9 @@ COPY go.mod go.sum ./
 COPY main.go .
 COPY handler ./handler
 COPY models ./models
+COPY store ./store
+COPY trigger ./trigger
+COPY clients ./clients
 RUN go build -o main main.go
 # Copy artifacts to a clean image
 FROM alpine:3.16

--- a/lambda/service/Dockerfile
+++ b/lambda/service/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.20.2-alpine3.16 as build
+WORKDIR /service
+# Copy dependencies list
+COPY go.mod go.sum ./
+# Build
+COPY main.go .
+RUN go build -o main main.go
+# Copy artifacts to a clean image
+FROM alpine:3.16
+COPY --from=build /service/main /main
+COPY ./entry_script.sh /entry_script.sh
+ADD aws-lambda-rie /usr/local/bin/aws-lambda-rie
+ENTRYPOINT [ "/entry_script.sh" ]

--- a/lambda/service/Dockerfile
+++ b/lambda/service/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /service
 # Copy dependencies list
 COPY go.mod go.sum ./
 # Build
-COPY main.go .
+COPY main.go . 
 COPY handler ./handler
 COPY models ./models
 COPY store ./store
@@ -13,7 +13,11 @@ COPY utils ./utils
 RUN go build -o main main.go
 # Copy artifacts to a clean image
 FROM alpine:3.16
+RUN apk add --update curl
 COPY --from=build /service/main /main
 COPY ./entry_script.sh /entry_script.sh
-ADD aws-lambda-rie /usr/local/bin/aws-lambda-rie
+# install aws-lambda-rie
+RUN curl -Lo aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie-arm64 \
+&& chmod +x aws-lambda-rie && mv aws-lambda-rie /usr/local/bin/aws-lambda-rie
+
 ENTRYPOINT [ "/entry_script.sh" ]

--- a/lambda/service/Dockerfile
+++ b/lambda/service/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang:1.20.2-alpine3.16 as build
 WORKDIR /service
-# Copy dependencies list
-COPY go.mod go.sum ./
-# Build
+# Copy files
 COPY . ./
+# Build
 RUN go build -o main main.go
 # Copy artifacts to a clean image
 FROM alpine:3.16

--- a/lambda/service/Dockerfile
+++ b/lambda/service/Dockerfile
@@ -3,13 +3,7 @@ WORKDIR /service
 # Copy dependencies list
 COPY go.mod go.sum ./
 # Build
-COPY main.go . 
-COPY handler ./handler
-COPY models ./models
-COPY store ./store
-COPY trigger ./trigger
-COPY clients ./clients
-COPY utils ./utils
+COPY . ./
 RUN go build -o main main.go
 # Copy artifacts to a clean image
 FROM alpine:3.16

--- a/lambda/service/Dockerfile.x64
+++ b/lambda/service/Dockerfile.x64
@@ -1,0 +1,16 @@
+FROM golang:1.20.2-alpine3.16 as build
+WORKDIR /service
+# Copy files
+COPY . ./
+# Build
+RUN go build -o main main.go
+# Copy artifacts to a clean image
+FROM alpine:3.16
+RUN apk add --update curl
+COPY --from=build /service/main /main
+COPY ./entry_script.sh /entry_script.sh
+# install aws-lambda-rie
+RUN curl -Lo aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie \
+&& chmod +x aws-lambda-rie && mv aws-lambda-rie /usr/local/bin/aws-lambda-rie
+
+ENTRYPOINT [ "/entry_script.sh" ]

--- a/lambda/service/clients/client.go
+++ b/lambda/service/clients/client.go
@@ -1,0 +1,7 @@
+package clients
+
+import "bytes"
+
+type Client interface {
+	Execute(b bytes.Buffer) ([]byte, error)
+}

--- a/lambda/service/clients/client.go
+++ b/lambda/service/clients/client.go
@@ -1,7 +1,10 @@
 package clients
 
-import "bytes"
+import (
+	"bytes"
+	"context"
+)
 
 type Client interface {
-	Execute(b bytes.Buffer) ([]byte, error)
+	Execute(context.Context, bytes.Buffer) ([]byte, error)
 }

--- a/lambda/service/clients/restClient.go
+++ b/lambda/service/clients/restClient.go
@@ -26,9 +26,9 @@ func (c *ApplicationRestClient) Execute(ctx context.Context, b bytes.Buffer) ([]
 		return nil, err
 	}
 
-	tiggerContext, cancel := context.WithTimeout(ctx, requestDuration)
+	triggerContext, cancel := context.WithTimeout(ctx, requestDuration)
 	defer cancel()
-	req = req.WithContext(tiggerContext)
+	req = req.WithContext(triggerContext)
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		log.Println(err)

--- a/lambda/service/clients/restClient.go
+++ b/lambda/service/clients/restClient.go
@@ -20,15 +20,15 @@ func NewApplicationRestClient(client *http.Client, url string) Client {
 
 func (c *ApplicationRestClient) Execute(ctx context.Context, b bytes.Buffer) ([]byte, error) {
 	requestDuration := 180 * time.Second
-	req, err := http.NewRequest("POST", c.ApplicationURL, &b)
-	tiggerContext, cancel := context.WithTimeout(ctx, requestDuration)
-	defer cancel()
-
-	req = req.WithContext(tiggerContext)
+	req, err := http.NewRequest(http.MethodPost, c.ApplicationURL, &b)
 	if err != nil {
 		log.Println(err)
 		return nil, err
 	}
+
+	tiggerContext, cancel := context.WithTimeout(ctx, requestDuration)
+	defer cancel()
+	req = req.WithContext(tiggerContext)
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		log.Println(err)

--- a/lambda/service/clients/restClient.go
+++ b/lambda/service/clients/restClient.go
@@ -2,9 +2,11 @@ package clients
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log"
 	"net/http"
+	"time"
 )
 
 type ApplicationRestClient struct {
@@ -16,9 +18,13 @@ func NewApplicationRestClient(client *http.Client, url string) Client {
 	return &ApplicationRestClient{client, url}
 }
 
-func (c *ApplicationRestClient) Execute(b bytes.Buffer) ([]byte, error) {
+func (c *ApplicationRestClient) Execute(ctx context.Context, b bytes.Buffer) ([]byte, error) {
+	requestDuration := 180 * time.Second
 	req, err := http.NewRequest("POST", c.ApplicationURL, &b)
-	// add request headers here
+	tiggerContext, cancel := context.WithTimeout(ctx, requestDuration)
+	defer cancel()
+
+	req = req.WithContext(tiggerContext)
 	if err != nil {
 		log.Println(err)
 		return nil, err

--- a/lambda/service/clients/restClient.go
+++ b/lambda/service/clients/restClient.go
@@ -1,0 +1,39 @@
+package clients
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+)
+
+type ApplicationRestClient struct {
+	Client         *http.Client
+	ApplicationURL string
+}
+
+func NewApplicationRestClient(client *http.Client, url string) Client {
+	return &ApplicationRestClient{client, url}
+}
+
+func (c *ApplicationRestClient) Execute(b bytes.Buffer) ([]byte, error) {
+	req, err := http.NewRequest("POST", c.ApplicationURL, &b)
+	// add request headers here
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	s, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Println(err)
+		return s, err
+	}
+	return s, nil
+}

--- a/lambda/service/docker-compose.yml
+++ b/lambda/service/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.9'
+
+services:
+
+  integration-service:
+    image: pennsieve/integration-service
+    volumes:
+      - $HOME/.aws-lambda-rie:/aws-lambda
+    container_name: integration-service
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    entrypoint: aws-lambda-rie /main
+    restart: always
+    ports:
+      - 9000:8080
+  
+  mock-service:
+    image: pennsieve/mock-service
+    container_name: mock-service
+    build:
+      context: $HOME/Projects/mock-service/
+      dockerfile: $HOME/Projects/mock-service/./Dockerfile
+    restart: always
+    ports:
+      - 8081:8081
+  

--- a/lambda/service/docker-compose.yml
+++ b/lambda/service/docker-compose.yml
@@ -4,8 +4,6 @@ services:
 
   integration-service:
     image: pennsieve/integration-service
-    volumes:
-      - $HOME/.aws-lambda-rie:/aws-lambda
     container_name: integration-service
     build:
       context: .
@@ -15,12 +13,12 @@ services:
     ports:
       - 9000:8080
   
-  mock-service:
-    image: pennsieve/mock-service
-    container_name: mock-service
+  mock-application:
+    image: pennsieve/mock-application
+    container_name: mock-application
     build:
-      context: $HOME/Projects/mock-service/
-      dockerfile: $HOME/Projects/mock-service/./Dockerfile
+      context: ./mock-application/
+      dockerfile: ./Dockerfile
     restart: always
     ports:
       - 8081:8081

--- a/lambda/service/entry_script.sh
+++ b/lambda/service/entry_script.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
+  exec /usr/local/bin/aws-lambda-rie /main $@
+else
+  exec /main $@
+fi

--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -1,0 +1,5 @@
+module github.com/pennsieve/integration-service/service
+
+go 1.20
+
+require github.com/aws/aws-lambda-go v1.41.0

--- a/lambda/service/go.sum
+++ b/lambda/service/go.sum
@@ -1,0 +1,6 @@
+github.com/aws/aws-lambda-go v1.41.0 h1:l/5fyVb6Ud9uYd411xdHZzSf2n86TakxzpvIoz7l+3Y=
+github.com/aws/aws-lambda-go v1.41.0/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/lambda/service/handler/errors.go
+++ b/lambda/service/handler/errors.go
@@ -1,0 +1,7 @@
+package handler
+
+import "errors"
+
+var ErrApplicationValidation = errors.New("application cannot be triggered")
+var ErrRunningTrigger = errors.New("error running trigger")
+var ErrUnmarshaling = errors.New("error unmarshaling body")

--- a/lambda/service/handler/errors.go
+++ b/lambda/service/handler/errors.go
@@ -5,3 +5,4 @@ import "errors"
 var ErrApplicationValidation = errors.New("application cannot be triggered")
 var ErrRunningTrigger = errors.New("error running trigger")
 var ErrUnmarshaling = errors.New("error unmarshaling body")
+var ErrUnsupportedRoute = errors.New("unsupported route")

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -1,0 +1,7 @@
+package handler
+
+import "fmt"
+
+func init() {
+	fmt.Println("handler code")
+}

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -9,6 +9,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambdacontext"
 	"github.com/pennsieve/integration-service/service/clients"
 	"github.com/pennsieve/integration-service/service/models"
 	"github.com/pennsieve/integration-service/service/store"
@@ -16,6 +17,11 @@ import (
 )
 
 func IntegrationServiceHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	if lc, ok := lambdacontext.FromContext(ctx); ok {
+		awsRequestID := lc.AwsRequestID
+		log.Println("Processing awsRequestID:", awsRequestID)
+	}
+
 	var integration models.Integration
 	if err := json.Unmarshal([]byte(request.Body), &integration); err != nil {
 		log.Println(err)

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -9,7 +9,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambdacontext"
 	"github.com/pennsieve/integration-service/service/clients"
 	"github.com/pennsieve/integration-service/service/models"
 	"github.com/pennsieve/integration-service/service/store"
@@ -17,14 +16,6 @@ import (
 )
 
 func IntegrationServiceHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
-	var awsRequestID string
-	if lc, ok := lambdacontext.FromContext(ctx); ok {
-		awsRequestID = lc.AwsRequestID
-	} else {
-		log.Println("awsRequestID not found")
-	}
-	fmt.Println("awsRequestID", awsRequestID)
-
 	var integration models.Integration
 	if err := json.Unmarshal([]byte(request.Body), &integration); err != nil {
 		log.Println(err)

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -3,23 +3,46 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
+	"log"
+
 	"github.com/aws/aws-lambda-go/events"
-	model "github.com/pennsieve/integration-service/service/models"
+	"github.com/pennsieve/integration-service/service/models"
+	"github.com/pennsieve/integration-service/service/store"
+	"github.com/pennsieve/integration-service/service/trigger"
 )
 
 func IntegrationServiceHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	body := []byte(request.Body)
-	var integration model.Integration
+	var integration models.Integration
 
 	err := json.Unmarshal(body, &integration)
 	if err != nil {
+		log.Println(err)
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: 500,
-			Body:       "error unmarshaling body",
-		}, err
+			Body:       "IntegrationServiceHandler",
+		}, errors.New("error unmarshaling body")
 	}
+
+	// get application data - API endpoint better than DB query
+	// /applications/<applicationId>
+	store := store.NewStore()
+	application, _ := store.GetById(integration.ApplicationID)
+
+	// trigger integration
+	t := trigger.NewApplicationTrigger(application, integration.TriggerPayload)
+	err = t.Run()
+	if err != nil {
+		log.Println(err)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       "IntegrationServiceHandler",
+		}, errors.New("error running trigger")
+	}
+
 	response := events.APIGatewayV2HTTPResponse{
 		StatusCode: 200,
 		Body: fmt.Sprintf("hello your sessionToken is %s, and your datasetId is %s",

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -1,7 +1,29 @@
 package handler
 
-import "fmt"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
 
-func init() {
-	fmt.Println("handler code")
+	"github.com/aws/aws-lambda-go/events"
+	model "github.com/pennsieve/integration-service/service/models"
+)
+
+func IntegrationServiceHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	body := []byte(request.Body)
+	var integration model.Integration
+
+	err := json.Unmarshal(body, &integration)
+	if err != nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       "error unmarshaling body",
+		}, err
+	}
+	response := events.APIGatewayV2HTTPResponse{
+		StatusCode: 200,
+		Body: fmt.Sprintf("hello your sessionToken is %s, and your datasetId is %s",
+			integration.SessionToken, integration.DatasetID),
+	}
+	return response, nil
 }

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"log"
@@ -14,50 +13,64 @@ import (
 	"github.com/pennsieve/integration-service/service/models"
 	"github.com/pennsieve/integration-service/service/store"
 	"github.com/pennsieve/integration-service/service/trigger"
+	"github.com/pennsieve/integration-service/service/utils"
 )
 
 func IntegrationServiceHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	handlerName := "IntegrationServiceHandler"
 	if lc, ok := lambdacontext.FromContext(ctx); ok {
-		awsRequestID := lc.AwsRequestID
-		log.Println("Processing awsRequestID:", awsRequestID)
+		log.Println("Processing awsRequestID:", lc.AwsRequestID)
 	}
 
-	var integration models.Integration
-	if err := json.Unmarshal([]byte(request.Body), &integration); err != nil {
-		log.Println(err)
-		return events.APIGatewayV2HTTPResponse{
-			StatusCode: 500,
-			Body:       "IntegrationServiceHandler",
-		}, ErrUnmarshaling
-	}
+	switch utils.ExtractRoute(request.RouteKey) {
+	case "/integrations":
+		switch request.RequestContext.HTTP.Method {
+		case "POST":
+			var integration models.Integration
+			if err := json.Unmarshal([]byte(request.Body), &integration); err != nil {
+				log.Println(err)
+				return events.APIGatewayV2HTTPResponse{
+					StatusCode: 500,
+					Body:       handlerName,
+				}, ErrUnmarshaling
+			}
 
-	// get application data
-	store := store.NewStore()
-	application, _ := store.GetById(integration.ApplicationID)
+			// TODO: expose an applications endpoint?
+			store := store.NewStore()
+			application, _ := store.GetById(integration.ApplicationID)
 
-	// trigger integration
-	client := clients.NewApplicationRestClient(&http.Client{}, application.URL)
-	applicationTrigger := trigger.NewApplicationTrigger(client, application,
-		integration.TriggerPayload)
-	if applicationTrigger.Validate() != nil {
+			// create application trigger
+			client := clients.NewApplicationRestClient(&http.Client{}, application.URL)
+			applicationTrigger := trigger.NewApplicationTrigger(client, application,
+				integration.TriggerPayload)
+			// validate
+			if applicationTrigger.Validate() != nil {
+				return events.APIGatewayV2HTTPResponse{
+					StatusCode: 409,
+					Body:       handlerName,
+				}, ErrApplicationValidation
+			}
+			// run
+			if err := applicationTrigger.Run(ctx); err != nil {
+				log.Println(err)
+				return events.APIGatewayV2HTTPResponse{
+					StatusCode: 500,
+					Body:       handlerName,
+				}, ErrRunningTrigger
+			}
+		}
+	default:
+		log.Println("unsupported route")
 		return events.APIGatewayV2HTTPResponse{
-			StatusCode: 409,
-			Body:       "IntegrationServiceHandler",
-		}, ErrApplicationValidation
-	}
+			StatusCode: 404,
+			Body:       handlerName,
+		}, ErrUnsupportedRoute
 
-	if err := applicationTrigger.Run(ctx); err != nil {
-		log.Println(err)
-		return events.APIGatewayV2HTTPResponse{
-			StatusCode: 500,
-			Body:       "IntegrationServiceHandler",
-		}, ErrRunningTrigger
 	}
 
 	response := events.APIGatewayV2HTTPResponse{
 		StatusCode: 200,
-		Body: fmt.Sprintf("routeKey: %s | sessionToken: %s | datasetId: %s",
-			request.RouteKey, integration.SessionToken, integration.DatasetID),
+		Body:       handlerName,
 	}
 	return response, nil
 }

--- a/lambda/service/handler/handler_test.go
+++ b/lambda/service/handler/handler_test.go
@@ -10,13 +10,20 @@ import (
 
 func TestIntegrationServiceHandler(t *testing.T) {
 	ctx := context.Background()
-	request := events.APIGatewayV2HTTPRequest{
-		Body: "{ \"sessionToken\": \"ae5t678999-a345fgg\", \"datasetI\": \"dataset123\", \"applicationId\": 1, \"payload\": {\"packageIds\": [1,2,3]}}",
+	requestContext := events.APIGatewayV2HTTPRequestContext{
+		HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+			Method: "POST",
+		},
 	}
-	expectedStatusCode := 200
+	request := events.APIGatewayV2HTTPRequest{
+		RouteKey:       "POST /IncorrectIntegrationsRoute",
+		Body:           "{ \"sessionToken\": \"ae5t678999-a345fgg\", \"datasetI\": \"dataset123\", \"applicationId\": 1, \"payload\": {\"packageIds\": [1,2,3]}}",
+		RequestContext: requestContext,
+	}
 
-	response, err := handler.IntegrationServiceHandler(ctx, request)
-	if err != nil {
+	expectedStatusCode := 404
+	response, _ := handler.IntegrationServiceHandler(ctx, request)
+	if response.StatusCode != expectedStatusCode {
 		t.Errorf("expected status code %v, got %v", expectedStatusCode, response.StatusCode)
 	}
 }

--- a/lambda/service/handler/handler_test.go
+++ b/lambda/service/handler/handler_test.go
@@ -11,7 +11,7 @@ import (
 func TestIntegrationServiceHandler(t *testing.T) {
 	ctx := context.Background()
 	request := events.APIGatewayV2HTTPRequest{
-		Body: "{ \"sessionToken\": \"xyz12345\",  \"datasetId\": \"data123\"}",
+		Body: "{ \"sessionToken\": \"ae5t678999-a345fgg\", \"datasetI\": \"dataset123\", \"applicationId\": 1, \"payload\": {\"packageIds\": [1,2,3]}}",
 	}
 	expectedStatusCode := 200
 

--- a/lambda/service/handler/handler_test.go
+++ b/lambda/service/handler/handler_test.go
@@ -1,0 +1,22 @@
+package handler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/pennsieve/integration-service/service/handler"
+)
+
+func TestIntegrationServiceHandler(t *testing.T) {
+	ctx := context.Background()
+	request := events.APIGatewayV2HTTPRequest{
+		Body: "{ \"sessionToken\": \"xyz12345\",  \"datasetId\": \"data123\"}",
+	}
+	expectedStatusCode := 200
+
+	response, err := handler.IntegrationServiceHandler(ctx, request)
+	if err != nil {
+		t.Errorf("expected status code %v, got %v", expectedStatusCode, response.StatusCode)
+	}
+}

--- a/lambda/service/handler/handler_test.go
+++ b/lambda/service/handler/handler_test.go
@@ -17,7 +17,7 @@ func TestIntegrationServiceHandler(t *testing.T) {
 	}
 	request := events.APIGatewayV2HTTPRequest{
 		RouteKey:       "POST /IncorrectIntegrationsRoute",
-		Body:           "{ \"sessionToken\": \"ae5t678999-a345fgg\", \"datasetI\": \"dataset123\", \"applicationId\": 1, \"payload\": {\"packageIds\": [1,2,3]}}",
+		Body:           "{ \"sessionToken\": \"ae5t678999-a345fgg\", \"datasetId\": \"dataset123\", \"applicationId\": 1, \"payload\": {\"packageIds\": [1,2,3]}}",
 		RequestContext: requestContext,
 	}
 

--- a/lambda/service/main.go
+++ b/lambda/service/main.go
@@ -1,20 +1,10 @@
 package main
 
 import (
-	"context"
-
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/pennsieve/integration-service/service/handler"
 )
 
-func IntegrationServiceHandler(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	response := events.APIGatewayProxyResponse{
-		StatusCode: 200,
-		Body:       "\"Hello from Integrations Service Lambda!\"",
-	}
-	return response, nil
-}
-
 func main() {
-	lambda.Start(IntegrationServiceHandler)
+	lambda.Start(handler.IntegrationServiceHandler)
 }

--- a/lambda/service/main.go
+++ b/lambda/service/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+func IntegrationServiceHandler(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	response := events.APIGatewayProxyResponse{
+		StatusCode: 200,
+		Body:       "\"Hello from Integrations Service Lambda!\"",
+	}
+	return response, nil
+}
+
+func main() {
+	lambda.Start(IntegrationServiceHandler)
+}

--- a/lambda/service/mock-application/Dockerfile
+++ b/lambda/service/mock-application/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.20.2-alpine3.16 as build
+WORKDIR /service
+# Copy dependencies list
+COPY go.mod ./
+# Build
+COPY main.go .
+RUN go build -o main main.go
+# Copy artifacts to a clean image
+FROM alpine:3.16
+COPY --from=build /service/main /main
+ENTRYPOINT [ "/main" ]

--- a/lambda/service/mock-application/go.mod
+++ b/lambda/service/mock-application/go.mod
@@ -1,0 +1,3 @@
+module github.com/pennsieve/mock-application
+
+go 1.20

--- a/lambda/service/mock-application/main.go
+++ b/lambda/service/mock-application/main.go
@@ -30,12 +30,12 @@ func NewHandler() http.Handler {
 }
 
 func main() {
-	fmt.Println("mock-service")
+	fmt.Println("mock-application")
 	srv := &http.Server{
 		Addr:    ":8081",
 		Handler: NewHandler(),
 	}
 
-	log.Println("Starting mock service ...")
+	log.Println("Starting mock application ...")
 	log.Fatal(srv.ListenAndServe())
 }

--- a/lambda/service/mock-application/main.go
+++ b/lambda/service/mock-application/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+type MockServiceHandler struct {
+}
+
+func (dh *MockServiceHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	_ = req.Context()
+	body := req.Body
+	defer body.Close()
+	rw.WriteHeader(http.StatusAccepted)
+	rw.Header().Set("Content-Type", "application/json")
+	var b bytes.Buffer
+	io.Copy(&b, body)
+	log.Print(b.String())
+	rw.Write(b.Bytes())
+}
+
+func NewHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("/mock", &MockServiceHandler{})
+	return mux
+}
+
+func main() {
+	fmt.Println("mock-service")
+	srv := &http.Server{
+		Addr:    ":8081",
+		Handler: NewHandler(),
+	}
+
+	log.Println("Starting mock service ...")
+	log.Fatal(srv.ListenAndServe())
+}

--- a/lambda/service/mocks/mocks.go
+++ b/lambda/service/mocks/mocks.go
@@ -1,0 +1,18 @@
+package mocks
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/pennsieve/integration-service/service/clients"
+)
+
+type MockClient struct{}
+
+func (c *MockClient) Execute(ctx context.Context, b bytes.Buffer) ([]byte, error) {
+	return nil, nil
+}
+
+func NewMockClient() clients.Client {
+	return &MockClient{}
+}

--- a/lambda/service/models/application.go
+++ b/lambda/service/models/application.go
@@ -1,0 +1,9 @@
+package models
+
+type Application struct {
+	ID         int64
+	Name       string
+	URL        string
+	IsActive   bool
+	IsInternal bool
+}

--- a/lambda/service/models/integration.go
+++ b/lambda/service/models/integration.go
@@ -5,7 +5,6 @@ type Integration struct {
 	DatasetID      string         `json:"datasetId"`
 	ApplicationID  int64          `json:"applicationId"`
 	TriggerPayload TriggerPayload `json:"payload"`
-	TriggerClient  string         `json:"client"`
 }
 
 type TriggerPayload struct {

--- a/lambda/service/models/integration.go
+++ b/lambda/service/models/integration.go
@@ -5,6 +5,7 @@ type Integration struct {
 	DatasetID      string         `json:"datasetId"`
 	ApplicationID  int64          `json:"applicationId"`
 	TriggerPayload TriggerPayload `json:"payload"`
+	TriggerClient  string         `json:"client"`
 }
 
 type TriggerPayload struct {

--- a/lambda/service/models/integration.go
+++ b/lambda/service/models/integration.go
@@ -1,0 +1,12 @@
+package model
+
+type Integration struct {
+	SessionToken  string            `json:"sessionToken"`
+	DatasetID     string            `json:"datasetId"`
+	ApplicationID int64             `json:"applicationId"`
+	Params        ApplicationParams `json:"params"`
+}
+
+type ApplicationParams struct {
+	PackageIDs []int64 `json:"packageIds"`
+}

--- a/lambda/service/models/integration.go
+++ b/lambda/service/models/integration.go
@@ -1,12 +1,12 @@
-package model
+package models
 
 type Integration struct {
-	SessionToken  string            `json:"sessionToken"`
-	DatasetID     string            `json:"datasetId"`
-	ApplicationID int64             `json:"applicationId"`
-	Params        ApplicationParams `json:"params"`
+	SessionToken   string         `json:"sessionToken"`
+	DatasetID      string         `json:"datasetId"`
+	ApplicationID  int64          `json:"applicationId"`
+	TriggerPayload TriggerPayload `json:"payload"`
 }
 
-type ApplicationParams struct {
+type TriggerPayload struct {
 	PackageIDs []int64 `json:"packageIds"`
 }

--- a/lambda/service/store/store.go
+++ b/lambda/service/store/store.go
@@ -17,7 +17,7 @@ func (r *ApplicationStore) GetById(applicationId int64) (models.Application, err
 	return models.Application{
 		ID:         applicationId,
 		Name:       "mockApplication",
-		URL:        "http://mock-service:8081/mock",
+		URL:        "http://mock-application:8081/mock",
 		IsActive:   true,
 		IsInternal: false,
 	}, nil

--- a/lambda/service/store/store.go
+++ b/lambda/service/store/store.go
@@ -17,7 +17,7 @@ func (r *ApplicationStore) GetById(applicationId int64) (models.Application, err
 	return models.Application{
 		ID:         applicationId,
 		Name:       "mockApplication",
-		URL:        "http://localhost:8081/mock",
+		URL:        "http://mock-service:8081/mock",
 		IsActive:   true,
 		IsInternal: false,
 	}, nil

--- a/lambda/service/store/store.go
+++ b/lambda/service/store/store.go
@@ -2,20 +2,20 @@ package store
 
 import "github.com/pennsieve/integration-service/service/models"
 
-type Store interface {
+type DatabaseStore interface {
 	GetById(int64) (models.Application, error)
 }
 
 type ApplicationStore struct {
 }
 
-func NewStore() Store {
+func NewStore() DatabaseStore {
 	return &ApplicationStore{}
 }
 
 func (r *ApplicationStore) GetById(applicationId int64) (models.Application, error) {
 	return models.Application{
-		ID:         1,
+		ID:         applicationId,
 		Name:       "mockApplication",
 		URL:        "http://localhost:8081/mock",
 		IsActive:   true,

--- a/lambda/service/store/store.go
+++ b/lambda/service/store/store.go
@@ -1,0 +1,24 @@
+package store
+
+import "github.com/pennsieve/integration-service/service/models"
+
+type Store interface {
+	GetById(int64) (models.Application, error)
+}
+
+type ApplicationStore struct {
+}
+
+func NewStore() Store {
+	return &ApplicationStore{}
+}
+
+func (r *ApplicationStore) GetById(applicationId int64) (models.Application, error) {
+	return models.Application{
+		ID:         1,
+		Name:       "mockApplication",
+		URL:        "http://localhost:8081/mock",
+		IsActive:   true,
+		IsInternal: false,
+	}, nil
+}

--- a/lambda/service/trigger/trigger.go
+++ b/lambda/service/trigger/trigger.go
@@ -1,0 +1,1 @@
+package trigger

--- a/lambda/service/trigger/trigger.go
+++ b/lambda/service/trigger/trigger.go
@@ -1,20 +1,35 @@
 package trigger
 
-import "github.com/pennsieve/integration-service/service/models"
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/pennsieve/integration-service/service/clients"
+	"github.com/pennsieve/integration-service/service/models"
+)
 
 type Trigger interface {
 	Run() error
 }
 
 type ApplicationTrigger struct {
+	Client      clients.Client
 	Application models.Application
 	Payload     models.TriggerPayload
 }
 
-func NewApplicationTrigger(application models.Application, payload models.TriggerPayload) Trigger {
-	return &ApplicationTrigger{application, payload}
+func NewApplicationTrigger(client clients.Client, application models.Application, payload models.TriggerPayload) Trigger {
+	return &ApplicationTrigger{client, application, payload}
 }
 
 func (t *ApplicationTrigger) Run() error {
+	b, err := json.Marshal(t.Payload)
+	if err != nil {
+		return err
+	}
+	_, err = t.Client.Execute(*bytes.NewBuffer(b))
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/lambda/service/trigger/trigger.go
+++ b/lambda/service/trigger/trigger.go
@@ -3,6 +3,8 @@ package trigger
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"log"
 
 	"github.com/pennsieve/integration-service/service/clients"
 	"github.com/pennsieve/integration-service/service/models"
@@ -10,6 +12,7 @@ import (
 
 type Trigger interface {
 	Run() error
+	Validate() error
 }
 
 type ApplicationTrigger struct {
@@ -22,6 +25,7 @@ func NewApplicationTrigger(client clients.Client, application models.Application
 	return &ApplicationTrigger{client, application, payload}
 }
 
+// runs trigger
 func (t *ApplicationTrigger) Run() error {
 	b, err := json.Marshal(t.Payload)
 	if err != nil {
@@ -29,6 +33,16 @@ func (t *ApplicationTrigger) Run() error {
 	}
 	_, err = t.Client.Execute(*bytes.NewBuffer(b))
 	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// validates whether a trigger can be executed
+func (t *ApplicationTrigger) Validate() error {
+	if !t.Application.IsActive {
+		err := errors.New("application should be active")
+		log.Println(err)
 		return err
 	}
 	return nil

--- a/lambda/service/trigger/trigger.go
+++ b/lambda/service/trigger/trigger.go
@@ -33,7 +33,8 @@ func (t *ApplicationTrigger) Run(ctx context.Context) error {
 		return err
 	}
 	_, err = t.Client.Execute(ctx, *bytes.NewBuffer(b))
-	// handle responses differently
+	// handle responses:
+	// currently we expect a 2xx response and no errors?
 	if err != nil {
 		return err
 	}

--- a/lambda/service/trigger/trigger.go
+++ b/lambda/service/trigger/trigger.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
@@ -11,7 +12,7 @@ import (
 )
 
 type Trigger interface {
-	Run() error
+	Run(ctx context.Context) error
 	Validate() error
 }
 
@@ -26,12 +27,13 @@ func NewApplicationTrigger(client clients.Client, application models.Application
 }
 
 // runs trigger
-func (t *ApplicationTrigger) Run() error {
+func (t *ApplicationTrigger) Run(ctx context.Context) error {
 	b, err := json.Marshal(t.Payload)
 	if err != nil {
 		return err
 	}
-	_, err = t.Client.Execute(*bytes.NewBuffer(b))
+	_, err = t.Client.Execute(ctx, *bytes.NewBuffer(b))
+	// handle responses differently
 	if err != nil {
 		return err
 	}

--- a/lambda/service/trigger/trigger.go
+++ b/lambda/service/trigger/trigger.go
@@ -1,1 +1,20 @@
 package trigger
+
+import "github.com/pennsieve/integration-service/service/models"
+
+type Trigger interface {
+	Run() error
+}
+
+type ApplicationTrigger struct {
+	Application models.Application
+	Payload     models.TriggerPayload
+}
+
+func NewApplicationTrigger(application models.Application, payload models.TriggerPayload) Trigger {
+	return &ApplicationTrigger{application, payload}
+}
+
+func (t *ApplicationTrigger) Run() error {
+	return nil
+}

--- a/lambda/service/trigger/trigger_test.go
+++ b/lambda/service/trigger/trigger_test.go
@@ -1,0 +1,31 @@
+package trigger_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/pennsieve/integration-service/service/clients"
+	"github.com/pennsieve/integration-service/service/models"
+	"github.com/pennsieve/integration-service/service/trigger"
+)
+
+func TestRun(t *testing.T) {
+	application := models.Application{
+		ID:         1,
+		Name:       "mockApplication",
+		URL:        "http://localhost:8081/mock",
+		IsActive:   true,
+		IsInternal: false,
+	}
+	triggerPayload := models.TriggerPayload{
+		PackageIDs: []int64{1, 2, 3},
+	}
+	client := clients.NewApplicationRestClient(&http.Client{}, application.URL)
+	applicationTrigger := trigger.NewApplicationTrigger(client,
+		application,
+		triggerPayload)
+	err := applicationTrigger.Run()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/lambda/service/trigger/trigger_test.go
+++ b/lambda/service/trigger/trigger_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/pennsieve/integration-service/service/trigger"
 )
 
+func TestValidate(t *testing.T) {
+	application := models.Application{
+		ID:         1,
+		Name:       "mockApplication",
+		URL:        "http://localhost:8081/mock",
+		IsActive:   false,
+		IsInternal: false,
+	}
+	triggerPayload := models.TriggerPayload{
+		PackageIDs: []int64{1, 2, 3},
+	}
+
+	mockClient := mocks.NewMockClient()
+	applicationTrigger := trigger.NewApplicationTrigger(mockClient, application, triggerPayload)
+	err := applicationTrigger.Validate()
+	expectedError := "application should be active"
+	if err.Error() != expectedError {
+		t.Errorf("expected: %s, got %s", expectedError, err)
+	}
+}
+
 func TestRun(t *testing.T) {
 	application := models.Application{
 		ID:         1,

--- a/lambda/service/trigger/trigger_test.go
+++ b/lambda/service/trigger/trigger_test.go
@@ -20,6 +20,7 @@ func TestRun(t *testing.T) {
 	triggerPayload := models.TriggerPayload{
 		PackageIDs: []int64{1, 2, 3},
 	}
+	// client to be mocked
 	client := clients.NewApplicationRestClient(&http.Client{}, application.URL)
 	applicationTrigger := trigger.NewApplicationTrigger(client,
 		application,

--- a/lambda/service/trigger/trigger_test.go
+++ b/lambda/service/trigger/trigger_test.go
@@ -1,10 +1,10 @@
 package trigger_test
 
 import (
-	"net/http"
+	"context"
 	"testing"
 
-	"github.com/pennsieve/integration-service/service/clients"
+	"github.com/pennsieve/integration-service/service/mocks"
 	"github.com/pennsieve/integration-service/service/models"
 	"github.com/pennsieve/integration-service/service/trigger"
 )
@@ -20,12 +20,11 @@ func TestRun(t *testing.T) {
 	triggerPayload := models.TriggerPayload{
 		PackageIDs: []int64{1, 2, 3},
 	}
-	// client to be mocked
-	client := clients.NewApplicationRestClient(&http.Client{}, application.URL)
-	applicationTrigger := trigger.NewApplicationTrigger(client,
-		application,
-		triggerPayload)
-	err := applicationTrigger.Run()
+
+	mockClient := mocks.NewMockClient()
+	applicationTrigger := trigger.NewApplicationTrigger(mockClient, application, triggerPayload)
+	ctx := context.Background()
+	err := applicationTrigger.Run(ctx)
 	if err != nil {
 		t.Error(err)
 	}

--- a/lambda/service/utils/utils.go
+++ b/lambda/service/utils/utils.go
@@ -1,0 +1,9 @@
+package utils
+
+import "regexp"
+
+func ExtractRoute(requestRouteKey string) string {
+	r := regexp.MustCompile(`(?P<method>) (?P<pathKey>.*)`)
+	routeKeyParts := r.FindStringSubmatch(requestRouteKey)
+	return routeKeyParts[r.SubexpIndex("pathKey")]
+}

--- a/lambda/service/utils/utils_test.go
+++ b/lambda/service/utils/utils_test.go
@@ -1,0 +1,20 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/pennsieve/integration-service/service/utils"
+)
+
+func TestExtractRouteKey(t *testing.T) {
+	request := events.APIGatewayV2HTTPRequest{
+		RouteKey: "POST /integrations",
+		Body:     "{ \"sessionToken\": \"ae5t678999-a345fgg\", \"datasetI\": \"dataset123\", \"applicationId\": 1, \"payload\": {\"packageIds\": [1,2,3]}}",
+	}
+	expected := "/integrations"
+	got := utils.ExtractRoute(request.RouteKey)
+	if got != expected {
+		t.Errorf("expected %s, got %s", expected, got)
+	}
+}

--- a/lambda/service/utils/utils_test.go
+++ b/lambda/service/utils/utils_test.go
@@ -10,7 +10,7 @@ import (
 func TestExtractRouteKey(t *testing.T) {
 	request := events.APIGatewayV2HTTPRequest{
 		RouteKey: "POST /integrations",
-		Body:     "{ \"sessionToken\": \"ae5t678999-a345fgg\", \"datasetI\": \"dataset123\", \"applicationId\": 1, \"payload\": {\"packageIds\": [1,2,3]}}",
+		Body:     "{ \"sessionToken\": \"ae5t678999-a345fgg\", \"datasetId\": \"dataset123\", \"applicationId\": 1, \"payload\": {\"packageIds\": [1,2,3]}}",
 	}
 	expected := "/integrations"
 	got := utils.ExtractRoute(request.RouteKey)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+set -e
+
+echo ""
+echo "**********************************"
+echo "*   Testing Integration Service Lambda   *"
+echo "**********************************"
+echo ""
+cd ./lambda/service; \
+  go test -v ./... ;

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -104,6 +104,58 @@ resource "aws_iam_role_policy_attachment" "event_integration_consumer_lambda_iam
   policy_arn = aws_iam_policy.event_integration_consumer_lambda_iam_policy.arn
 }
 
+## Integration Service
+resource "aws_iam_role" "integration_service_lambda_role" {
+  name = "${var.environment_name}-${var.service_name}-integration-service-lambda-role-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "integration_service_lambda_iam_policy" {
+  name   = "${var.environment_name}-${var.service_name}-integration-service-lambda-iam-policy-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  path   = "/"
+  policy = data.aws_iam_policy_document.integration_service_lambda_iam_policy_document.json
+}
+
+data "aws_iam_policy_document" "integration_service_lambda_iam_policy_document" {
+  statement {
+    sid    = "EventIntegrationConsumerPermissions"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutDestination",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+      "ec2:AssignPrivateIpAddresses",
+      "ec2:UnassignPrivateIpAddresses"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "integration_service_lambda_iam_policy_attachment" {
+  role       = aws_iam_role.integration_service_lambda_role.name
+  policy_arn = aws_iam_policy.integration_service_lambda_iam_policy.arn
+}
+
 ##########################
 # SQS Queue Key Policies #
 ##########################

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "event_integration_consumer_lambda" {
   timeout          = 60
   memory_size      = 128
   s3_bucket         = var.lambda_bucket
-  s3_key            = "${var.service_name}/${var.service_name}-${var.image_tag}.zip"
+  s3_key            = "${var.service_name}/event_handler/${var.service_name}-${var.image_tag}.zip"
 
   vpc_config {
     subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
@@ -21,6 +21,31 @@ resource "aws_lambda_function" "event_integration_consumer_lambda" {
       ENV = var.environment_name
       PENNSIEVE_DOMAIN = data.terraform_remote_state.account.outputs.domain_name,
 #      WEBHOOK_SQS_QUEUE_NAME = aws_sqs_queue.webhook_integration_queue.name
+    }
+  }
+}
+
+## Lambda Function for Integration Service.
+resource "aws_lambda_function" "integration_service_lambda" {
+  description      = "Lambda Function which provides the interface for integration applications"
+  function_name    = "${var.environment_name}-${var.service_name}-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  handler          = "integration-service"
+  runtime          = "provided.al2"
+  role             = aws_iam_role.integration_service_lambda_role.arn
+  timeout          = 30
+  memory_size      = 128
+  s3_bucket         = var.lambda_bucket
+  s3_key            = "${var.service_name}/service/${var.service_name}-${var.image_tag}.zip"
+
+  vpc_config {
+    subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
+    security_group_ids = [data.terraform_remote_state.platform_infrastructure.outputs.integration_service_security_group_id]
+  }
+
+  environment {
+    variables = {
+      ENV = var.environment_name
+      PENNSIEVE_DOMAIN = data.terraform_remote_state.account.outputs.domain_name,
     }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -13,3 +13,8 @@ output "integration_events_sns_topic_name" {
 output "integration_events_kms_key_arn" {
   value = aws_kms_key.event_integration_sqs_kms_key.arn
 }
+
+## Service Lambda arn
+output "service_lambda_arn" {
+  value = aws_lambda_function.integration_service_lambda.arn
+}


### PR DESCRIPTION
Related: https://app.clickup.com/t/86850z93q

This PR sets up the work for enabling us the ability to integrate pennsieve with custom applications.

The PR includes:
- the lambda for receiving the gateway event, processing it and  then triggering a POST request to an external application
-  it also includes a mock application for local testing
- docker files for local testing (with the ability to run the lambda locally). See testing documentation below.

This PR primarily addresses requirement (1.)

Local Testing documented on the related ticket: https://app.clickup.com/t/86850z93q?comment=90110006448032

TODOs:
-  setup upstream tests and write more tests
- authorization
- logging
- determine course of action for where to retrieve the application data
- wiring it all up so its routed through the gateway

Risks

- Code currently unused so can be merged without negative impact.
 