### PR TITLE
uses organizationId derived from claim

### DIFF
--- a/lambda/service/handler/post_integrations_handler.go
+++ b/lambda/service/handler/post_integrations_handler.go
@@ -42,7 +42,7 @@ func PostIntegrationsHandler(ctx context.Context, request events.APIGatewayV2HTT
 
 	log.Println("connected to DB")
 
-	store := store.NewApplicationDatabaseStore(db, integration.OrganizationID)
+	store := store.NewApplicationDatabaseStore(db, organizationId)
 	application, err := store.GetById(ctx, integration.ApplicationID)
 	if err != nil {
 		log.Println(err.Error())


### PR DESCRIPTION
- gets organizationId int from claim, so it does not have to be passed in the payload