### PR TITLE
AppStore: creates integrations dynamodb table

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -1,0 +1,69 @@
+resource "aws_dynamodb_table" "integrations_table" {
+  name           = "${var.environment_name}-integrations-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "uuid"
+  range_key      = "applicationId"
+
+  attribute {
+    name = "uuid"
+    type = "S"
+  }
+
+  attribute {
+    name = "applicationId"
+    type = "N"
+  }
+
+  attribute {
+    name = "datasetNodeId"
+    type = "S"
+  }
+
+  attribute {
+    name = "packageIds"
+    type = "S"
+  }
+
+  attribute {
+    name = "params"
+    type = "S"
+  }
+
+  attribute {
+    name = "taskId"
+    type = "S"
+  }
+
+  attribute {
+    name = "start"
+    type = "N"
+  }
+
+  attribute {
+    name = "end"
+    type = "N"
+  }
+
+  
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = false
+  }
+
+  global_secondary_index {
+    name               = "ApplicationIdIndex"
+    hash_key           = "applicationId"
+    range_key          = "datasetNodeId"
+    projection_type    = "INCLUDE"
+    non_key_attributes = ["uuid"]
+  }
+
+tags = merge(
+  local.common_tags,
+  {
+    "Name"         = "${var.environment_name}-integrations-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+    "name"         = "${var.environment_name}-integrations-table-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+    "service_name" = var.service_name
+  },
+  )
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -150,6 +150,28 @@ data "aws_iam_policy_document" "integration_service_lambda_iam_policy_document" 
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid = "LambdaAccessToDynamoDB"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem"
+    ]
+
+    resources = [
+      aws_dynamodb_table.integrations_table.arn,
+      "${aws_dynamodb_table.integrations_table.arn}/*"
+    ]
+
+  }
+
 }
 
 resource "aws_iam_role_policy_attachment" "integration_service_lambda_iam_policy_attachment" {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -50,6 +50,7 @@ resource "aws_lambda_function" "integration_service_lambda" {
       RDS_PROXY_ENDPOINT = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
       REGION = var.aws_region,
       LOG_LEVEL = "info",
+      INTEGRATIONS_TABLE = aws_dynamodb_table.integrations_table.name,
     }
   }
 }


### PR DESCRIPTION
- creates integrations dynamo db table
- this table will be used to persist integrations and so that we can GET data from the external applications via the integrationId