### PR TITLE
fix dynamo errors

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -10,7 +10,7 @@ resource "aws_dynamodb_table" "integrations_table" {
   
   ttl {
     attribute_name = "TimeToExist"
-    enabled        = false
+    enabled        = true
   }
 
 tags = merge(


### PR DESCRIPTION
- fix :

```
 Error: updating Amazon DynamoDB Table (dev-integrations-table-use1): updating Time To Live: ValidationException: TimeToLive is already disabled
│ 	status code: 400, request id:
```