### PR TITLE
creates a trigger specific context

### DIFF
--- a/lambda/service/handler/post_integrations_handler.go
+++ b/lambda/service/handler/post_integrations_handler.go
@@ -79,7 +79,7 @@ func PostIntegrationsHandler(ctx context.Context, request events.APIGatewayV2HTT
 		}, ErrApplicationValidation
 	}
 	// run
-	if err := applicationTrigger.Run(ctx); err != nil {
+	if err := applicationTrigger.Run(context.Background()); err != nil {
 		log.Println(err.Error())
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: 500,


### PR DESCRIPTION
- fix error:

```
2023/11/12 04:06:45 
{
    "errorMessage": "error running trigger",
    "errorType": "errorString"
}
```