### PR TITLE
fix: return params in GET response

### DIFF
--- a/lambda/service/handler/get_integrations_handler.go
+++ b/lambda/service/handler/get_integrations_handler.go
@@ -44,6 +44,7 @@ func GetIntegrationsHandler(ctx context.Context, request events.APIGatewayV2HTTP
 		ApplicationID: integration.ApplicationId,
 		DatasetNodeID: integration.DatasetNodeId,
 		PackageIDs:    integration.PackageIds,
+		Params:        integration.Params,
 	})
 	if err != nil {
 		log.Println(err.Error())


### PR DESCRIPTION
Related:  https://app.clickup.com/t/8686zqg7k

- return params in GET response

RISK : **LOW**

