### PR TITLE
fix: omits compute node URL when not provided

### DIFF
--- a/lambda/service/models/integration.go
+++ b/lambda/service/models/integration.go
@@ -12,5 +12,5 @@ type Integration struct {
 
 type ComputeNode struct {
 	ComputeNodeUuid       string `json:"uuid"`
-	ComputeNodeGatewayUrl string `json:"computeNodeGatewayUrl"`
+	ComputeNodeGatewayUrl string `json:"computeNodeGatewayUrl,omitempty"`
 }


### PR DESCRIPTION
- omits compute node URL when not provided