### PR TITLE
fix: allows for backward compatibility

### DIFF
--- a/lambda/service/handler/get_integration_handler.go
+++ b/lambda/service/handler/get_integration_handler.go
@@ -16,7 +16,15 @@ import (
 
 func GetIntegrationHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	handlerName := "GetIntegrationHandler"
-	uuid := request.PathParameters["id"]
+	var uuid string
+	idValue, ok := request.PathParameters["id"]
+	if ok {
+		uuid = idValue
+	}
+	integrationIdValue, ok := request.PathParameters["integration_id"]
+	if ok {
+		uuid = integrationIdValue
+	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -18,10 +18,11 @@ func IntegrationServiceHandler(ctx context.Context, request events.APIGatewayV2H
 	applicationAuthorizer := authorization.NewApplicationAuthorizer(request)
 	router := NewLambdaRouter(applicationAuthorizer)
 	// register routes based on their supported methods
-	router.POST("/integrations", PostIntegrationsHandler)   // deprecated
-	router.GET("/integrations", GetIntegrationsHandler)     // deprecated
-	router.GET("/integrations/{id}", GetIntegrationHandler) // deprecated
-	router.PUT("/integrations", PutIntegrationsHandler)     // deprecated
+	router.POST("/integrations", PostIntegrationsHandler)               // deprecated
+	router.GET("/integrations", GetIntegrationsHandler)                 // deprecated
+	router.GET("/integrations/{id}", GetIntegrationHandler)             // deprecated
+	router.GET("/integrations/{integration_id}", GetIntegrationHandler) // deprecated, backward-compatibility
+	router.PUT("/integrations", PutIntegrationsHandler)                 // deprecated
 
 	router.POST("/workflows", PostWorkflowsHandler)
 	router.POST("/workflows/instances", PostWorkflowInstancesHandler)


### PR DESCRIPTION
- allows for backward compatibility with old route (prior to deploying pennsieve-go-api)