### PR TITLE
Add missing IAM permission for API Gateway and Integration Service Lambda

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -49,6 +49,18 @@ data "terraform_remote_state" "account" {
   }
 }
 
+# Import API Gateway
+data "terraform_remote_state" "api_gateway" {
+  backend = "s3"
+
+  config = {
+    bucket  = "${var.aws_account}-terraform-state"
+    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/pennsieve-go-api/terraform.tfstate"
+    region  = "us-east-1"
+    profile = var.aws_account
+  }
+}
+
 # Import Postgres
 data "terraform_remote_state" "pennsieve_postgres" {
   backend = "s3"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -125,6 +125,14 @@ resource "aws_iam_role" "integration_service_lambda_role" {
 EOF
 }
 
+resource "aws_lambda_permission" "integration_service_api_api_gateway_lambda_permission" {
+  statement_id  = "AllowExecutionFromGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.integration_service_lambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn = "${data.terraform_remote_state.api_gateway.outputs.execution_arn}/*"
+}
+
 resource "aws_iam_policy" "integration_service_lambda_iam_policy" {
   name   = "${var.environment_name}-${var.service_name}-integration-service-lambda-iam-policy-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   path   = "/"


### PR DESCRIPTION
## Description
The API Gateway was lacking Terraform permission to `InvokeFunction` this service Lambda function.

This required developers to manually make changes in the AWS Console every time a new route it added to the service.

This PR adds the required permissions to Terraform.

## Terraform Plan
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.service_module.aws_lambda_permission.integration_service_api_api_gateway_lambda_permission will be created
  + resource "aws_lambda_permission" "integration_service_api_api_gateway_lambda_permission" {
      + action              = "lambda:InvokeFunction"
      + function_name       = "dev-integration-service-lambda-use1"
      + id                  = (known after apply)
      + principal           = "apigateway.amazonaws.com"
      + source_arn          = "arn:aws:execute-api:us-east-1:941165240011:14i0ufp7jh/*"
      + statement_id        = "AllowExecutionFromGateway"
      + statement_id_prefix = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```