### PR TITLE
868bffvuc fix: workflow instance status table environment variable

### DIFF
--- a/lambda/service/handler/post_workflow_instances_handler.go
+++ b/lambda/service/handler/post_workflow_instances_handler.go
@@ -43,7 +43,9 @@ func PostWorkflowInstancesHandler(ctx context.Context, request events.APIGateway
 
 	integrationsTable := os.Getenv("INTEGRATIONS_TABLE")
 	dynamo_store := store_dynamodb.NewWorkflowInstanceDatabaseStore(dynamoDBClient, integrationsTable)
-	workflow_instance_status_dynamo_store := store_dynamodb.NewWorkflowInstanceStatusDatabaseStore(dynamoDBClient, integrationsTable)
+
+	workflowInstanceStatusTable := os.Getenv("WORKFLOW_INSTANCE_STATUS_TABLE")
+	workflow_instance_status_dynamo_store := store_dynamodb.NewWorkflowInstanceStatusDatabaseStore(dynamoDBClient, workflowInstanceStatusTable)
 
 	// create compute node trigger
 	httpClient := clients.NewComputeRestClient(&http.Client{}, integration.ComputeNode.ComputeNodeGatewayUrl)


### PR DESCRIPTION
## Description
Fixes a bug introduced in: https://github.com/Pennsieve/integration-service/pull/58

The wrong environment variable was being used to specify the workflow instance status table dynamodb table name.