### PR TITLE
868bffvuc Fix: DynamoDB Range Key

### DIFF
--- a/lambda/service/store_dynamodb/workflow_instance_status.go
+++ b/lambda/service/store_dynamodb/workflow_instance_status.go
@@ -1,8 +1,25 @@
 package store_dynamodb
 
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
 type WorkflowInstanceStatus struct {
 	WorkflowInstanceUuid string `dynamodbav:"workflowInstanceUuid"`
 	ProcessorUuid        string `dynamodbav:"processorUuid"`
 	Status               string `dynamodbav:"status"`
 	Timestamp            int    `dynamodbav:"timestamp"`
+}
+
+func (s WorkflowInstanceStatus) GetKey() map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"workflowInstanceUuid": &types.AttributeValueMemberS{
+			Value: s.WorkflowInstanceUuid,
+		},
+		"processorUuid#timestamp": &types.AttributeValueMemberS{
+			Value: fmt.Sprintf("%s#%d", s.ProcessorUuid, s.Timestamp),
+		},
+	}
 }

--- a/lambda/service/store_dynamodb/workflow_instance_status_store_dynamodb.go
+++ b/lambda/service/store_dynamodb/workflow_instance_status_store_dynamodb.go
@@ -57,6 +57,11 @@ func (r *WorkflowInstanceStatusDatabaseStore) Put(ctx context.Context, uuid stri
 
 	item, err := attributevalue.MarshalMap(status)
 
+	pk := status.GetKey()
+	for k, v := range pk {
+		item[k] = v
+	}
+
 	if err != nil {
 		return err
 	}

--- a/lambda/service/store_dynamodb/workflow_instance_status_store_dynamodb_test.go
+++ b/lambda/service/store_dynamodb/workflow_instance_status_store_dynamodb_test.go
@@ -71,14 +71,14 @@ func CreateWorkflowInstanceStatusTable(dynamoDBClient *dynamodb.Client, tableNam
 			AttributeName: aws.String("workflowInstanceUuid"),
 			AttributeType: types.ScalarAttributeTypeS,
 		}, {
-			AttributeName: aws.String("timestamp"),
-			AttributeType: types.ScalarAttributeTypeN,
+			AttributeName: aws.String("processorUuid#timestamp"),
+			AttributeType: types.ScalarAttributeTypeS,
 		}},
 		KeySchema: []types.KeySchemaElement{{
 			AttributeName: aws.String("workflowInstanceUuid"),
 			KeyType:       types.KeyTypeHash,
 		}, {
-			AttributeName: aws.String("timestamp"),
+			AttributeName: aws.String("processorUuid#timestamp"),
 			KeyType:       types.KeyTypeRange,
 		}},
 		TableName:   aws.String(tableName),

--- a/lambda/service/store_dynamodb/workflow_instance_status_store_dynamodb_test.go
+++ b/lambda/service/store_dynamodb/workflow_instance_status_store_dynamodb_test.go
@@ -40,6 +40,18 @@ func TestPutGetAllWorkflowInstanceStatuses(t *testing.T) {
 		t.Errorf("error inserting items into table: %v", err)
 	}
 
+	// test new processor, same timestamp and status
+	statusEvent = models.WorkflowInstanceStatusEvent{
+		Uuid:      uuid.NewString(),
+		Status:    models.WorkflowInstanceStatusNotStarted,
+		Timestamp: int(now),
+	}
+	err = dynamo_store.Put(context.Background(), workflowInstanceId, statusEvent)
+	if err != nil {
+		t.Errorf("error inserting items into table: %v", err)
+	}
+
+	// test new status for processor
 	statusEvent = models.WorkflowInstanceStatusEvent{
 		Uuid:      processorId,
 		Status:    models.WorkflowInstanceStatusStarted,
@@ -55,7 +67,7 @@ func TestPutGetAllWorkflowInstanceStatuses(t *testing.T) {
 		t.Errorf("error getting item in table: %v", err)
 	}
 
-	assert.Len(t, statuses, 2)
+	assert.Len(t, statuses, 3)
 
 	// delete table
 	err = DeleteTable(dynamoDBClient, tableName)

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -52,7 +52,7 @@ resource "aws_dynamodb_table" "workflow_instance_status_table" {
   name         = "${var.environment_name}-workflow-instance-status-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "workflowInstanceUuid"
-  range_key    = "timestamp"
+  range_key    = "processorUuid#timestamp"
 
   attribute {
     name = "workflowInstanceUuid"
@@ -60,8 +60,8 @@ resource "aws_dynamodb_table" "workflow_instance_status_table" {
   }
 
   attribute {
-    name = "timestamp"
-    type = "N"
+    name = "processorUuid#timestamp"
+    type = "S"
   }
 
   tags = merge(


### PR DESCRIPTION
## Description
Follow-up to: https://github.com/Pennsieve/integration-service/pull/58

The primary key on the workflow instance status DynamoDB table was insufficiently unique. This caused items to replae one another instead of appending new records. This change ensures that more than one unique (workflow instance, status, timestamp) record can be stored across processors.

## Terraform Plan
```
Terraform will perform the following actions:

  # module.service_module.data.aws_iam_policy_document.integration_service_lambda_iam_policy_document will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "integration_service_lambda_iam_policy_document"  {
      ~ id      = "893085701" -> (known after apply)
      ~ json    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "rds-db:connect",
                          - "logs:PutLogEvents",
                          - "logs:PutDestination",
                          - "logs:DescribeLogStreams",
                          - "logs:CreateLogStream",
                          - "logs:CreateLogGroup",
                          - "ec2:UnassignPrivateIpAddresses",
                          - "ec2:DescribeNetworkInterfaces",
                          - "ec2:DeleteNetworkInterface",
                          - "ec2:CreateNetworkInterface",
                          - "ec2:AssignPrivateIpAddresses",
                        ]
                      - Effect   = "Allow"
                      - Resource = "*"
                      - Sid      = "EventIntegrationConsumerPermissions"
                    },
                  - {
                      - Action   = [
                          - "dynamodb:UpdateItem",
                          - "dynamodb:Scan",
                          - "dynamodb:Query",
                          - "dynamodb:PutItem",
                          - "dynamodb:GetItem",
                          - "dynamodb:BatchWriteItem",
                          - "dynamodb:BatchGetItem",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflows-table-use1/*",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflows-table-use1",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflow-instance-status-use1/*",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflow-instance-status-use1",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-integrations-table-use1/*",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-integrations-table-use1",
                        ]
                      - Sid      = "LambdaAccessToDynamoDB"
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
      - version = "2012-10-17" -> null

      ~ statement {
          - not_actions   = [] -> null
          - not_resources = [] -> null
            # (4 unchanged attributes hidden)
        }
      ~ statement {
          - not_actions   = [] -> null
          - not_resources = [] -> null
          ~ resources     = [
              - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflow-instance-status-use1",
              - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflow-instance-status-use1/*",
              ~ (known after apply),
              ~ (known after apply),
                # (4 unchanged elements hidden)
            ]
            # (3 unchanged attributes hidden)
        }
    }

  # module.service_module.aws_dynamodb_table.workflow_instance_status_table must be replaced
-/+ resource "aws_dynamodb_table" "workflow_instance_status_table" {
      ~ arn                         = "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflow-instance-status-use1" -> (known after apply)
      - deletion_protection_enabled = false -> null
      ~ id                          = "dev-workflow-instance-status-use1" -> (known after apply)
        name                        = "dev-workflow-instance-status-use1"
      ~ range_key                   = "timestamp" -> "processorUuid#timestamp" # forces replacement
      ~ read_capacity               = 0 -> (known after apply)
      + stream_arn                  = (known after apply)
      - stream_enabled              = false -> null
      + stream_label                = (known after apply)
      + stream_view_type            = (known after apply)
      - table_class                 = "STANDARD" -> null
        tags                        = {
            "Name"             = "dev-workflow-instance-status-use1"
            "aws_account"      = "pennsieve-non-prod"
            "aws_region"       = "us-east-1"
            "environment_name" = "dev"
            "name"             = "dev-workflow-instance-status-use1"
            "service_name"     = "integration-service"
        }
      ~ write_capacity              = 0 -> (known after apply)
        # (3 unchanged attributes hidden)

      + attribute {
          + name = "processorUuid#timestamp"
          + type = "S"
        }
      - attribute {
          - name = "timestamp" -> null
          - type = "N" -> null
        }

      ~ point_in_time_recovery {
          ~ enabled = false -> (known after apply)
        }

      + server_side_encryption {
          + enabled     = (known after apply)
          + kms_key_arn = (known after apply)
        }

      ~ ttl {
          + attribute_name = (known after apply)
          ~ enabled        = false -> (known after apply)
        }
        # (1 unchanged block hidden)
    }

  # module.service_module.aws_iam_policy.integration_service_lambda_iam_policy will be updated in-place
  ~ resource "aws_iam_policy" "integration_service_lambda_iam_policy" {
        id        = "arn:aws:iam::941165240011:policy/dev-integration-service-integration-service-lambda-iam-policy-use1"
        name      = "dev-integration-service-integration-service-lambda-iam-policy-use1"
      ~ policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "rds-db:connect",
                          - "logs:PutLogEvents",
                          - "logs:PutDestination",
                          - "logs:DescribeLogStreams",
                          - "logs:CreateLogStream",
                          - "logs:CreateLogGroup",
                          - "ec2:UnassignPrivateIpAddresses",
                          - "ec2:DescribeNetworkInterfaces",
                          - "ec2:DeleteNetworkInterface",
                          - "ec2:CreateNetworkInterface",
                          - "ec2:AssignPrivateIpAddresses",
                        ]
                      - Effect   = "Allow"
                      - Resource = "*"
                      - Sid      = "EventIntegrationConsumerPermissions"
                    },
                  - {
                      - Action   = [
                          - "dynamodb:UpdateItem",
                          - "dynamodb:Scan",
                          - "dynamodb:Query",
                          - "dynamodb:PutItem",
                          - "dynamodb:GetItem",
                          - "dynamodb:BatchWriteItem",
                          - "dynamodb:BatchGetItem",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflows-table-use1/*",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflows-table-use1",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflow-instance-status-use1/*",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-workflow-instance-status-use1",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-integrations-table-use1/*",
                          - "arn:aws:dynamodb:us-east-1:941165240011:table/dev-integrations-table-use1",
                        ]
                      - Sid      = "LambdaAccessToDynamoDB"
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        tags      = {}
        # (4 unchanged attributes hidden)
    }

  # module.service_module.aws_lambda_function.event_integration_consumer_lambda will be updated in-place
  ~ resource "aws_lambda_function" "event_integration_consumer_lambda" {
        id                             = "dev-integration-service-event-consumer-lambda-use1"
      ~ last_modified                  = "2025-01-28T17:07:29.000+0000" -> (known after apply)
      ~ s3_key                         = "integration-service/event_handler/integration-service-rohan-local-20250128120646.zip" -> "integration-service/event_handler/integration-service-rohan-local-20250128141009.zip"
        tags                           = {}
        # (22 unchanged attributes hidden)




        # (4 unchanged blocks hidden)
    }

  # module.service_module.aws_lambda_function.integration_service_lambda will be updated in-place
  ~ resource "aws_lambda_function" "integration_service_lambda" {
        id                             = "dev-integration-service-lambda-use1"
      ~ last_modified                  = "2025-01-28T17:07:29.000+0000" -> (known after apply)
      ~ s3_key                         = "integration-service/service/integration-service-rohan-local-20250128120646.zip" -> "integration-service/service/integration-service-rohan-local-20250128141009.zip"
        tags                           = {}
        # (22 unchanged attributes hidden)




        # (4 unchanged blocks hidden)
    }

Plan: 1 to add, 3 to change, 1 to destroy.
```