### PR TITLE
add IAM permissions for new dynamodb table

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -179,7 +179,9 @@ data "aws_iam_policy_document" "integration_service_lambda_iam_policy_document" 
       aws_dynamodb_table.workflows_table.arn,
       "${aws_dynamodb_table.workflows_table.arn}/*",
       aws_dynamodb_table.workflow_instance_status_table.arn,
-      "${aws_dynamodb_table.workflow_instance_status_table.arn}/*"
+      "${aws_dynamodb_table.workflow_instance_status_table.arn}/*",
+      aws_dynamodb_table.workflow_instance_processor_status_table.arn,
+      "${aws_dynamodb_table.workflow_instance_processor_status_table.arn}/*"
     ]
 
   }


### PR DESCRIPTION
## Description
Follow-up to: https://github.com/Pennsieve/integration-service/pull/63

Forgot to add IAM permissions for the Lambda to access the new DynamoDB table.