### PR TITLE
fix: returns runName in GET request

### DIFF
--- a/lambda/service/handler/get_workflow_instance_handler.go
+++ b/lambda/service/handler/get_workflow_instance_handler.go
@@ -41,6 +41,7 @@ func GetWorkflowInstanceHandler(ctx context.Context, request events.APIGatewayV2
 
 	m, err := json.Marshal(models.WorkflowInstance{
 		Uuid: integration.Uuid,
+		Name: integration.Name,
 		ComputeNode: models.ComputeNode{
 			ComputeNodeUuid:       integration.ComputeNodeUuid,
 			ComputeNodeGatewayUrl: integration.ComputeNodeGatewayUrl,


### PR DESCRIPTION
Related: https://app.clickup.com/t/868d4nxt9

The runName is returned for the call to GET /workflow/instances, but not the call to GET a specific workflow instance.

- this fix returns runName in GET workflow instance call