### PR TITLE
fix: uses the same context throughout

### DIFF
--- a/lambda/service/credentials_retriever/credentials_retriever.go
+++ b/lambda/service/credentials_retriever/credentials_retriever.go
@@ -27,7 +27,7 @@ func NewAWSCredentialsRetriever(accountId string, cfg aws.Config) Retriever {
 func (r *AWSCredentialsRetriever) Run(ctx context.Context) (aws.Credentials, error) {
 	log.Println("assuming role ...")
 
-	cfg, err := config.LoadDefaultConfig(context.Background())
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return aws.Credentials{}, err
 	}


### PR DESCRIPTION
- uses the same context throughout