### PR TITLE
Lock down /webhook: shared secret, size cap, per-sender rate limit

### DIFF
--- a/internal/db/webhook_messages.go
+++ b/internal/db/webhook_messages.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Pennsieve/integration-service/internal/models"
 )
@@ -26,4 +27,34 @@ func InsertWebhookMessage(ctx context.Context, requestID string, payload []byte)
 		return models.IncomingWebhook{}, fmt.Errorf("insert webhook message: %w", err)
 	}
 	return rec, nil
+}
+
+// RecordSenderRequest increments the fixed-window request counter for
+// senderIP and returns the count after recording this request. The window
+// resets (count goes back to 1) once it's older than window. The upsert is
+// a single atomic statement so concurrent Lambda invocations for the same
+// sender can't race past each other and both see a stale count.
+func RecordSenderRequest(ctx context.Context, senderIP string, window time.Duration) (int, error) {
+	const q = `
+		INSERT INTO webhooks.sender_rate_limits (sender_ip, window_start, request_count)
+		VALUES ($1, now(), 1)
+		ON CONFLICT (sender_ip) DO UPDATE SET
+			window_start = CASE
+				WHEN webhooks.sender_rate_limits.window_start <= now() - ($2 * interval '1 second')
+				THEN now()
+				ELSE webhooks.sender_rate_limits.window_start
+			END,
+			request_count = CASE
+				WHEN webhooks.sender_rate_limits.window_start <= now() - ($2 * interval '1 second')
+				THEN 1
+				ELSE webhooks.sender_rate_limits.request_count + 1
+			END
+		RETURNING request_count`
+
+	var count int
+	err := dbPool.QueryRowContext(ctx, q, senderIP, window.Seconds()).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("record sender request: %w", err)
+	}
+	return count, nil
 }

--- a/internal/dbmigrate/migrations/20260709000000_create_webhooks_sender_rate_limits.down.sql
+++ b/internal/dbmigrate/migrations/20260709000000_create_webhooks_sender_rate_limits.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS webhooks.sender_rate_limits;

--- a/internal/dbmigrate/migrations/20260709000000_create_webhooks_sender_rate_limits.up.sql
+++ b/internal/dbmigrate/migrations/20260709000000_create_webhooks_sender_rate_limits.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS webhooks.sender_rate_limits (
+    sender_ip     TEXT        PRIMARY KEY,
+    window_start  TIMESTAMPTZ NOT NULL,
+    request_count INTEGER     NOT NULL
+);

--- a/internal/handler/webhook_handler.go
+++ b/internal/handler/webhook_handler.go
@@ -2,11 +2,16 @@ package handler
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/Pennsieve/integration-service/internal/aws"
 	"github.com/Pennsieve/integration-service/internal/db"
@@ -24,19 +29,104 @@ var allowedMethods = map[string]bool{
 	http.MethodDelete: true,
 }
 
+var env = os.Getenv("ENV")
+
+const (
+	// sharedSecretHeaderName is the HTTP header senders must set with a
+	// pre-shared secret. Requests missing it or presenting the wrong value
+	// are discarded before any DB work happens.
+	sharedSecretHeaderName = "X-Pennsieve-Webhook-Secret"
+
+	// maxPayloadBytes bounds the raw (still-possibly-base64-encoded) request
+	// body. Checked before base64 decoding so an oversized body is rejected
+	// without spending CPU/memory decoding it first.
+	maxPayloadBytes = 1 << 20 // 1 MiB
+
+	// maxRequestsPerSender/senderRateLimitWindow bound how often a single
+	// source IP may successfully reach the DB within a sliding window.
+	maxRequestsPerSender  = 60
+	senderRateLimitWindow = time.Minute
+)
+
+var (
+	webhookSecretOnce sync.Once
+	webhookSecret     string
+	webhookSecretErr  error
+)
+
+// setSharedSecretForTest overrides the cached webhook shared secret,
+// bypassing SSM. Mirrors db.SetPoolForTest.
+func setSharedSecretForTest(secret string) {
+	webhookSecretOnce = sync.Once{}
+	webhookSecretOnce.Do(func() {
+		webhookSecret = secret
+		webhookSecretErr = nil
+	})
+}
+
+// ensureWebhookSecret fetches the shared secret once per Lambda execution
+// environment and caches it, following the same pattern as db.EnsureDB.
+func ensureWebhookSecret(ctx context.Context) (string, error) {
+	webhookSecretOnce.Do(func() {
+		webhookSecret, webhookSecretErr = aws.GetSSMParam(ctx, fmt.Sprintf("/%s/integration-service/webhook-shared-secret", env), true)
+	})
+	return webhookSecret, webhookSecretErr
+}
+
+// hasValidSharedSecret reports whether the request carries the expected
+// shared secret. Header lookup is case-insensitive since API Gateway/Lambda
+// event payloads don't guarantee a particular header key casing.
+func hasValidSharedSecret(ctx context.Context, headers map[string]string) bool {
+	expected, err := ensureWebhookSecret(ctx)
+	if err != nil || expected == "" {
+		log.Printf("ERROR webhook shared secret unavailable: %v", err)
+		return false
+	}
+
+	var provided string
+	for k, v := range headers {
+		if strings.EqualFold(k, sharedSecretHeaderName) {
+			provided = v
+			break
+		}
+	}
+	if provided == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) == 1
+}
+
 func WebhookHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
 	aws.AwsOnce.Do(func() {
 		aws.InitAWS(ctx)
 	})
+
+	method := req.RequestContext.HTTP.Method
+	if !allowedMethods[method] {
+		return errorResponse(http.StatusMethodNotAllowed, fmt.Sprintf("method %s not allowed", method)), nil
+	}
+
+	if !hasValidSharedSecret(ctx, req.Headers) {
+		return errorResponse(http.StatusUnauthorized, "invalid or missing shared secret"), nil
+	}
+
+	if len(req.Body) > maxPayloadBytes {
+		return errorResponse(http.StatusRequestEntityTooLarge, "payload too large"), nil
+	}
 
 	if err := db.EnsureDB(ctx); err != nil {
 		log.Printf("ERROR db init: %v", err)
 		return errorResponse(http.StatusInternalServerError, "database unavailable"), nil
 	}
 
-	method := req.RequestContext.HTTP.Method
-	if !allowedMethods[method] {
-		return errorResponse(http.StatusMethodNotAllowed, fmt.Sprintf("method %s not allowed", method)), nil
+	senderIP := req.RequestContext.HTTP.SourceIP
+	count, err := db.RecordSenderRequest(ctx, senderIP, senderRateLimitWindow)
+	if err != nil {
+		log.Printf("ERROR sender rate limit check: %v", err)
+		return errorResponse(http.StatusInternalServerError, "failed to process request"), nil
+	}
+	if count > maxRequestsPerSender {
+		return errorResponse(http.StatusTooManyRequests, "rate limit exceeded"), nil
 	}
 
 	requestID, err := newUUID()
@@ -57,10 +147,6 @@ func WebhookHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (e
 		body = "{}"
 	}
 	payload := []byte(body)
-	const maxBodyBytes = 1 << 20
-	if len(payload) > maxBodyBytes {
-		return errorResponse(http.StatusBadRequest, "payload too large"), nil
-	}
 	if !json.Valid(payload) {
 		return errorResponse(http.StatusBadRequest, "payload must be valid JSON"), nil
 	}

--- a/internal/handler/webhook_handler_test.go
+++ b/internal/handler/webhook_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,16 +20,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testSharedSecret = "test-shared-secret"
+
 func markAWSReady() {
 	aws.AwsOnce.Do(func() {})
+	setSharedSecretForTest(testSharedSecret)
 }
 
 func lambdaReq(method, body string) events.LambdaFunctionURLRequest {
 	return events.LambdaFunctionURLRequest{
 		Body: body,
+		Headers: map[string]string{
+			sharedSecretHeaderName: testSharedSecret,
+		},
 		RequestContext: events.LambdaFunctionURLRequestContext{
 			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
-				Method: method,
+				Method:   method,
+				SourceIP: "203.0.113.10",
 			},
 		},
 	}
@@ -38,6 +46,14 @@ func lambdaReqBase64(method, body string) events.LambdaFunctionURLRequest {
 	req := lambdaReq(method, body)
 	req.IsBase64Encoded = true
 	return req
+}
+
+// expectRateLimitQuery sets up the sqlmock expectation for the
+// webhooks.sender_rate_limits upsert that every request past the shared
+// secret and size checks must go through.
+func expectRateLimitQuery(mock sqlmock.Sqlmock, count int) {
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO webhooks.sender_rate_limits")).
+		WillReturnRows(sqlmock.NewRows([]string{"request_count"}).AddRow(count))
 }
 
 func TestNewUUID(t *testing.T) {
@@ -98,11 +114,12 @@ func TestWebhookHandler_MethodNotAllowed(t *testing.T) {
 }
 
 func TestWebhookHandler_InvalidJSON(t *testing.T) {
-	mockDB, _, err := sqlmock.New()
+	mockDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer mockDB.Close()
 	db.SetPoolForTest(mockDB)
 	markAWSReady()
+	expectRateLimitQuery(mock, 1)
 
 	resp, err := WebhookHandler(context.Background(), lambdaReq(http.MethodPost, "not-json"))
 	require.NoError(t, err)
@@ -121,6 +138,7 @@ func TestWebhookHandler_EmptyBody(t *testing.T) {
 	markAWSReady()
 
 	now := time.Now()
+	expectRateLimitQuery(mock, 1)
 	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO webhooks.messages")).
 		WithArgs(sqlmock.AnyArg(), []byte("{}")).
 		WillReturnRows(
@@ -153,6 +171,7 @@ func TestWebhookHandler_Success(t *testing.T) {
 			now := time.Now()
 			reqID := fmt.Sprintf("uuid-%s", method)
 
+			expectRateLimitQuery(mock, 1)
 			mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO webhooks.messages")).
 				WithArgs(sqlmock.AnyArg(), []byte(payload)).
 				WillReturnRows(
@@ -187,6 +206,7 @@ func TestWebhookHandler_Base64EncodedBody(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
 	now := time.Now()
 
+	expectRateLimitQuery(mock, 1)
 	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO webhooks.messages")).
 		WithArgs(sqlmock.AnyArg(), []byte(payload)).
 		WillReturnRows(
@@ -205,11 +225,12 @@ func TestWebhookHandler_Base64EncodedBody(t *testing.T) {
 }
 
 func TestWebhookHandler_Base64EncodedBody_Invalid(t *testing.T) {
-	mockDB, _, err := sqlmock.New()
+	mockDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer mockDB.Close()
 	db.SetPoolForTest(mockDB)
 	markAWSReady()
+	expectRateLimitQuery(mock, 1)
 
 	resp, err := WebhookHandler(context.Background(), lambdaReqBase64(http.MethodPost, "not-valid-base64!!"))
 	require.NoError(t, err)
@@ -228,6 +249,7 @@ func TestWebhookHandler_DBInsertFailure(t *testing.T) {
 	db.SetPoolForTest(mockDB)
 	markAWSReady()
 
+	expectRateLimitQuery(mock, 1)
 	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO webhooks.messages")).
 		WillReturnError(fmt.Errorf("connection reset"))
 
@@ -239,5 +261,108 @@ func TestWebhookHandler_DBInsertFailure(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(resp.Body), &body))
 	assert.Contains(t, body.Message, "store webhook message")
 
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookHandler_MissingSharedSecret(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer mockDB.Close()
+	db.SetPoolForTest(mockDB)
+	markAWSReady()
+
+	req := lambdaReq(http.MethodPost, `{"k":"v"}`)
+	delete(req.Headers, sharedSecretHeaderName)
+
+	resp, err := WebhookHandler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var body models.WebhookResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &body))
+	assert.Contains(t, body.Message, "shared secret")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookHandler_InvalidSharedSecret(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer mockDB.Close()
+	db.SetPoolForTest(mockDB)
+	markAWSReady()
+
+	req := lambdaReq(http.MethodPost, `{"k":"v"}`)
+	req.Headers[sharedSecretHeaderName] = "wrong-secret"
+
+	resp, err := WebhookHandler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var body models.WebhookResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &body))
+	assert.Contains(t, body.Message, "shared secret")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookHandler_SharedSecretHeaderIsCaseInsensitive(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer mockDB.Close()
+	db.SetPoolForTest(mockDB)
+	markAWSReady()
+	expectRateLimitQuery(mock, 1)
+
+	payload := `{"event":"test"}`
+	now := time.Now()
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO webhooks.messages")).
+		WithArgs(sqlmock.AnyArg(), []byte(payload)).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "request_id", "payload", "received_at"}).
+				AddRow(1, "test-uuid", []byte(payload), now),
+		)
+
+	req := lambdaReq(http.MethodPost, payload)
+	delete(req.Headers, sharedSecretHeaderName)
+	req.Headers[strings.ToLower(sharedSecretHeaderName)] = testSharedSecret
+
+	resp, err := WebhookHandler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookHandler_PayloadTooLarge(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer mockDB.Close()
+	db.SetPoolForTest(mockDB)
+	markAWSReady()
+
+	oversized := strings.Repeat("a", maxPayloadBytes+1)
+	resp, err := WebhookHandler(context.Background(), lambdaReq(http.MethodPost, oversized))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+
+	var body models.WebhookResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &body))
+	assert.Contains(t, body.Message, "too large")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWebhookHandler_RateLimitExceeded(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer mockDB.Close()
+	db.SetPoolForTest(mockDB)
+	markAWSReady()
+	expectRateLimitQuery(mock, maxRequestsPerSender+1)
+
+	resp, err := WebhookHandler(context.Background(), lambdaReq(http.MethodPost, `{"k":"v"}`))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+
+	var body models.WebhookResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &body))
+	assert.Contains(t, body.Message, "rate limit")
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -1,9 +1,9 @@
-# NOTE: authorization_type = "NONE" on the /webhook route is an intentional,
-# temporary decision for testing — this makes the endpoint a public,
-# unauthenticated write endpoint that lets anyone on the internet
-# POST/PUT/PATCH/DELETE a row into webhooks.messages. This must be locked
-# down (IAM auth, or at minimum a shared secret / WAF rule) before this
-# pattern is used anywhere near prod.
+# NOTE: authorization_type = "NONE" on the /webhook route means API Gateway
+# itself performs no auth — the endpoint is reachable by anyone on the
+# internet. Authorization is instead enforced by the Lambda handler, which
+# requires a shared secret (see aws_ssm_parameter.webhook_shared_secret) in
+# the X-Pennsieve-Webhook-Secret header, and also applies a payload size cap
+# and a per-sender rate limit before touching the DB.
 resource "aws_apigatewayv2_api" "integration_service_api" {
   name          = "${var.environment_name}-${var.service_name}-api-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   protocol_type = "HTTP"

--- a/terraform/integration-service.yml
+++ b/terraform/integration-service.yml
@@ -1,0 +1,157 @@
+#file: noinspection MaybeTerraformTemplateInspection
+# NOTE: this spec is not yet wired into Terraform (the API Gateway in
+# gateway.tf is defined via individual aws_apigatewayv2_* resources, not an
+# imported OpenAPI body) and there is no .github/workflows/rdme-openapi.yml
+# in this repo yet. It exists so that if/when integration-service adopts the
+# org-standard OpenAPI-driven gateway + ReadMe publishing pattern used by
+# workflow-service, packages-service, etc., /webhook is already marked
+# x-internal: true and gets stripped before anything is published to
+# https://docs.pennsieve.io.
+openapi: 3.0.1
+info:
+  version: "3.0"
+  title: Integration Service
+  description: |
+    The Integration Service webhook receiver
+  termsOfService: https://docs.pennsieve.io/page/pennsieve-terms-of-use
+  contact:
+    name: Pennsieve Support
+    email: support@pennsieve.net
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: https://api2.pennsieve.io/integration
+    description: Production server
+  - url: https://api2.pennsieve.net/integration
+    description: Development server
+externalDocs:
+  description: Find more info here
+  url: https://docs.pennsieve.io
+tags:
+  - name: Webhooks
+    description: Internal webhook ingestion for integration testing
+
+components:
+  securitySchemes:
+    shared_secret_auth:
+      type: apiKey
+      name: X-Pennsieve-Webhook-Secret
+      in: header
+  responses:
+    Unauthorized:
+      description: Missing or invalid shared secret
+    TooManyRequests:
+      description: Sender rate limit exceeded
+    Error:
+      description: Unexpected error
+
+paths:
+  /webhook:
+    post:
+      summary: Receive a webhook payload
+      description: |
+        Stores an incoming webhook payload for integration testing. Internal
+        only — never publish this endpoint to the public API docs.
+      operationId: receiveWebhook
+      x-internal: true
+      security:
+        - shared_secret_auth: [ ]
+      tags:
+        - Webhooks
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        '202':
+          description: Payload accepted and stored
+        '400':
+          description: Malformed body
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          description: Payload too large
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '5XX':
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Receive a webhook payload
+      operationId: receiveWebhookPut
+      x-internal: true
+      security:
+        - shared_secret_auth: [ ]
+      tags:
+        - Webhooks
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        '202':
+          description: Payload accepted and stored
+        '400':
+          description: Malformed body
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          description: Payload too large
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '5XX':
+          $ref: '#/components/responses/Error'
+    patch:
+      summary: Receive a webhook payload
+      operationId: receiveWebhookPatch
+      x-internal: true
+      security:
+        - shared_secret_auth: [ ]
+      tags:
+        - Webhooks
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        '202':
+          description: Payload accepted and stored
+        '400':
+          description: Malformed body
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          description: Payload too large
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '5XX':
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Receive a webhook payload
+      operationId: receiveWebhookDelete
+      x-internal: true
+      security:
+        - shared_secret_auth: [ ]
+      tags:
+        - Webhooks
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        '202':
+          description: Payload accepted and stored
+        '400':
+          description: Malformed body
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          description: Payload too large
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '5XX':
+          $ref: '#/components/responses/Error'

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -27,3 +27,19 @@ resource "aws_ssm_parameter" "integrations_postgres_password" {
     ignore_changes = [value]
   }
 }
+
+// WEBHOOK RECEIVER CONFIGURATION
+// Shared secret senders must present in the X-Pennsieve-Webhook-Secret
+// header. Terraform only creates the parameter with a placeholder value;
+// the real value is rotated by hand in SSM/console, same as the DB password
+// above.
+resource "aws_ssm_parameter" "webhook_shared_secret" {
+  name      = "/${var.environment_name}/${var.service_name}/webhook-shared-secret"
+  overwrite = false
+  type      = "SecureString"
+  value     = "dummy"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}


### PR DESCRIPTION
## Summary

`gateway.tf` sets `authorization_type = "NONE"` on the `/webhook` route — API Gateway itself performs no auth, so this adds application-layer protections in the Lambda handler, checked cheapest-first so bad traffic never reaches the DB:

- **Shared secret** — requires header `X-Pennsieve-Webhook-Secret`, compared with `crypto/subtle.ConstantTimeCompare` against a value cached from a new SSM param `/${ENV}/integration-service/webhook-shared-secret` (`terraform/ssm.tf`, same rotate-by-hand pattern as the DB password). Missing/wrong → `401`.
- **Size cap** — the raw (pre-base64-decode) body is checked against 1 MiB before any decoding happens. Over → `413`.
- **Sender frequency** — a new `webhooks.sender_rate_limits` table (migration added) tracks a fixed-window counter per source IP via an atomic upsert; default 60 requests/minute. Exceeded → `429`.

Also adds `terraform/integration-service.yml`, an OpenAPI spec marking `/webhook` `x-internal: true` on every operation — the same convention `workflow-service`'s `rdme-openapi.yml` action uses to strip endpoints before publishing to https://docs.pennsieve.io. This repo has no such publishing pipeline yet (gateway.tf defines the API via individual `aws_apigatewayv2_*` resources, not an OpenAPI-body import), so nothing can leak today; this pre-guards the endpoint for whenever the repo is onboarded to that pattern.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` all pass
- [x] New/updated tests cover: missing shared secret, invalid shared secret, case-insensitive header lookup, oversized payload, rate-limit exceeded, plus all existing success/error paths (now wired through the new checks)
- [x] Verified the new migration loads cleanly via `dbmigrate.MigrationsSource()`
- [ ] Terraform not available locally to `terraform validate` — plan should be reviewed on apply
- [ ] Real value for the `webhook-shared-secret` SSM param needs to be set by hand after apply (Terraform only seeds a `"dummy"` placeholder, `overwrite = false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)