### PR TITLE
Bump go-cloudwrap base image to 1.25-alpine

### DIFF
--- a/Dockerfile.cloudwrap-dbmigrate
+++ b/Dockerfile.cloudwrap-dbmigrate
@@ -1,4 +1,4 @@
-FROM pennsieve/go-cloudwrap:1.23-alpine
+FROM pennsieve/go-cloudwrap:1.25-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Bumps the `go-cloudwrap` base image used by the dbmigrate build (`Dockerfile.cloudwrap-dbmigrate`) from `pennsieve/go-cloudwrap:1.23-alpine` to `pennsieve/go-cloudwrap:1.25-alpine`, per the new Cloudwrap release (https://github.com/Pennsieve/cloudwrap).

## Notes for reviewer
- This is the only place in the repo that references the Cloudwrap base image (checked Makefile, Jenkinsfile, terraform — no other pinned references).
- `go build ./...` passes locally against the existing `go 1.23.0` module directive; no other code changes were needed.
- Docker wasn't available in the sandbox this was prepared in, so the actual image build/pull against the new tag hasn't been verified — worth confirming in CI before merging.

## Test plan
- [ ] CI builds `Dockerfile.cloudwrap-dbmigrate` successfully with the new base image tag
- [ ] dbmigrate image runs and executes migrations as expected