### PR TITLE
Log auth error on notification 401 path

### DIFF
--- a/internal/handler/notification_handler.go
+++ b/internal/handler/notification_handler.go
@@ -43,6 +43,7 @@ func NotificationHandler(ctx context.Context, req events.APIGatewayV2HTTPRequest
 
 	userID, err := authenticatedUserID(req)
 	if err != nil {
+		log.Printf("ERROR auth: %v; authorizer=%+v", err, req.RequestContext.Authorizer)
 		return notifErrorResponse(http.StatusUnauthorized, "missing or invalid bearer token"), nil
 	}
 


### PR DESCRIPTION
## Summary
- `authenticatedUserID` collapses two distinct internal failures — no Lambda authorizer context reaching the handler vs. a present context missing `user_claim` — into the same generic `401 missing or invalid bearer token` response, and the underlying error was silently discarded at the call site.
- Every other non-2xx fault path in this file logs its error first; the auth path was the one exception, leaving no way to tell the two failure modes apart in CloudWatch.
- Adds a single log line before returning the 401, logging both the error and the raw `req.RequestContext.Authorizer` context, so production 401s are diagnosable. Response body to the caller is unchanged — no error detail is leaked externally.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/handler/...`