### PR TITLE
Fixed payload format version

### DIFF
--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -44,11 +44,12 @@ resource "aws_cloudwatch_log_group" "integration_service_api_gateway_log_group" 
 }
 
 resource "aws_apigatewayv2_integration" "webhook_integration" {
-  api_id             = aws_apigatewayv2_api.integration_service_api.id
-  integration_type   = "AWS_PROXY"
-  connection_type    = "INTERNET"
-  integration_method = "POST"
-  integration_uri    = aws_lambda_function.webhook_receiver_lambda.invoke_arn
+  api_id                 = aws_apigatewayv2_api.integration_service_api.id
+  integration_type       = "AWS_PROXY"
+  connection_type        = "INTERNET"
+  integration_method     = "POST"
+  integration_uri        = aws_lambda_function.webhook_receiver_lambda.invoke_arn
+  payload_format_version = "2.0"
 }
 
 resource "aws_apigatewayv2_route" "webhook_route" {
@@ -96,11 +97,12 @@ resource "aws_apigatewayv2_authorizer" "pennsieve_lambda_authorizer" {
 }
 
 resource "aws_apigatewayv2_integration" "notification_integration" {
-  api_id             = aws_apigatewayv2_api.integration_service_api.id
-  integration_type   = "AWS_PROXY"
-  connection_type    = "INTERNET"
-  integration_method = "POST"
-  integration_uri    = aws_lambda_function.notification_lambda.invoke_arn
+  api_id                 = aws_apigatewayv2_api.integration_service_api.id
+  integration_type       = "AWS_PROXY"
+  connection_type        = "INTERNET"
+  integration_method     = "POST"
+  integration_uri        = aws_lambda_function.notification_lambda.invoke_arn
+  payload_format_version = "2.0"
 }
 
 resource "aws_apigatewayv2_route" "notification_get_topics_route" {


### PR DESCRIPTION
*Set HTTP API integration payload format to 2.0 (notification + webhook integrations)*

*Problem*

Calls to the /notification/* endpoints with a valid bearer token return 401 {"code":401,"message":"missing or invalid bearer token"} from the handler, even though the shared Lambda authorizer authorizes the request. (A request with no token returns API Gateway's own 401 Unauthorized; a bad token returns 403 Forbidden — both confirm the authorizer runs and enforces, so a valid token is being authorized and reaching the handler.)

The handler reads the caller's identity from req.RequestContext.Authorizer.Lambda ([internal/handler/notification_handler.go:160](internal/handler/notification_handler.go:160)), which is where an HTTP API payload-format-2.0 event carries Lambda authorizer context. Logging the authorizer at the failure site shows:

ERROR auth: no lambda authorizer context; authorizer=&{JWT:<nil> Lambda:map[] IAM:<nil>}

The Authorizer object is present, but .Lambda is nil — the context arrived, just not where a 2.0 event places it.

*Root cause*

The aws_apigatewayv2_integration resources in [terraform/gateway.tf](terraform/gateway.tf) do not set payload_format_version. For an HTTP API AWS_PROXY integration this defaults to 1.0. Under payload format 1.0, Lambda authorizer context is delivered flat at requestContext.authorizer rather than at requestContext.authorizer.lambda. The handler uses the 2.0 event type (events.APIGatewayV2HTTPRequest) and reads .Authorizer.Lambda, so it finds nothing and returns 401. The authorizer itself is configured correctly and identically to the working services (verified via get-authorizers); the only mismatch is the integration's event format.

*Change*

Set payload_format_version = "2.0" on both integrations in terraform/gateway.tf:

hcl
resource "aws_apigatewayv2_integration" "notification_integration" {
  api_id                 = aws_apigatewayv2_api.integration_service_api.id
  integration_type       = "AWS_PROXY"
  connection_type        = "INTERNET"
  integration_method     = "POST"
  integration_uri        = aws_lambda_function.notification_lambda.invoke_arn
  payload_format_version = "2.0"
}

resource "aws_apigatewayv2_integration" "webhook_integration" {
  api_id                 = aws_apigatewayv2_api.integration_service_api.id
  integration_type       = "AWS_PROXY"
  connection_type        = "INTERNET"
  integration_method     = "POST"
  integration_uri        = aws_lambda_function.webhook_receiver_lambda.invoke_arn
  payload_format_version = "2.0"
}

The webhook integration has the same defect and must be fixed too: webhook_handler reads req.RequestContext.HTTP.Method and .HTTP.SourceIP, both populated only under payload format 2.0, so the webhook path is broken in the same way and simply hasn't been exercised yet.